### PR TITLE
Feature/log events on timeout

### DIFF
--- a/tasks/blanket_qunit.js
+++ b/tasks/blanket_qunit.js
@@ -30,6 +30,7 @@ module.exports = function(grunt) {
         moduleTotalStatements : {},
         moduleTotalCoveredStatements : {}
     };
+    var lastEvents = [];
 
     // Keep track of the last-started module, test and status.
     var currentModule, currentTest, status, coverageThreshold, modulePattern, modulePatternRegex, verbose, lcovOpt, stripFilePrefix;
@@ -42,6 +43,13 @@ module.exports = function(grunt) {
     if(consoleOpt){
         consoleOpt = true;
     }
+
+    var pushEvent = function(event) {
+    	if(lastEvents.length >= 10){
+    		lastEvents = lastEvents.slice(1); //remove the first
+    	}
+    	lastEvents.push(event) // add to end
+    };
 
     // Get an asset file, local to the root of the project.
     var asset = path.join.bind(null, __dirname, '..');
@@ -188,6 +196,7 @@ module.exports = function(grunt) {
     phantomjs.on('qunit.*', function() {
         var args = [this.event].concat(grunt.util.toArray(arguments));
         grunt.event.emit.apply(grunt.event, args);
+        pushEvent(args);
     });
 
     // Built-in error handlers.
@@ -201,7 +210,14 @@ module.exports = function(grunt) {
     phantomjs.on('fail.timeout', function() {
         phantomjs.halt();
         grunt.log.writeln();
+        grunt.log.writeln('Last captured qunit events: ');
+        //it's a stack, loop backwords
+        for (var i = lastEvents.length - 1; i >= 0; i--) {
+
+        	grunt.log.writeln(lastEvents[i]);
+        };
         grunt.warn('PhantomJS timed out, possibly due to a missing QUnit start() call.');
+
     });
 
     // Pass-through console.log statements.

--- a/tasks/blanket_qunit.js
+++ b/tasks/blanket_qunit.js
@@ -213,9 +213,10 @@ module.exports = function(grunt) {
         grunt.log.writeln('Last captured qunit events: ');
         //it's a stack, loop backwords
         for (var i = lastEvents.length - 1; i >= 0; i--) {
-
         	grunt.log.writeln(lastEvents[i]);
         };
+	grunt.log.writeln('Last Module: ' + currentModule);
+	grunt.log.writeln('Last Test: ' + currentTest);
         grunt.warn('PhantomJS timed out, possibly due to a missing QUnit start() call.');
 
     });


### PR DESCRIPTION
```
Running "blanket_qunit:all" (blanket_qunit) task
Testing http://localhost:35730/admin/qunit.html?coverage=true&gruntReport
Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op.
Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op.
Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op.

Last captured qunit events: 
qunit.log,true,{
  "endItemPosition": 2,
  "endItemType": 1,
  "endItems": [],
  "endState": 8,
  "id": null,
  "loading": false,
  "name": "",
  "operationType": "Add",
  "startItemPosition": 1,
  "startItemType": 1,
  "startItems": [],
  "startState": 9
},{
  "endItemPosition": 2,
  "endItemType": 1,
  "endItems": [],
  "endState": 8,
  "id": null,
  "loading": false,
  "name": "",
  "operationType": "Add",
  "startItemPosition": 1,
  "startItemType": 1,
  "startItems": [],
  "startState": 9
},Default values applied successfully,
qunit.log,true,true,true,Component created successfully,
qunit.testStart,Duration Modal component and default values
qunit.moduleStart,Care Config Settings -- duration modal
qunit.moduleDone,Care Config Settings -- report count,0,6,6
qunit.testDone,Count Modal verify input changes and saving,0,4,4
qunit.log,true,{
  "excludeLabels": [],
  "id": 26,
  "labels": [
    {
      "id": 5,
      "title": "#facebook"
    }
  ],
  "labelsCombination": 1,
  "loading": true,
  "name": "Super Count Report",
  "operationType": "Edit",
  "type": "count"
},{
  "excludeLabels": [],
  "id": 26,
  "labels": [
    {
      "id": 5,
      "title": "#facebook"
    }
  ],
  "labelsCombination": 1,
  "loading": true,
  "name": "Super Count Report",
  "operationType": "Edit",
  "type": "count"
},Saving expected config,
qunit.log,true,true,true,Save Button is not disabled,
qunit.log,true,true,true,Save Button is disabled for empty labels,
qunit.log,true,{
  "excludeLabels": [
    {
      "id": 2,
      "title": "#responded"
    }
  ],
  "id": 26,
  "labels": [
    {
      "id": 35,
      "title": "#opened"
    }
  ],
  "labelsCombination": 2,
  "loading": false,
  "name": "Count Report",
  "operationType": "Edit"
},{
  "excludeLabels": [
    {
      "id": 2,
      "title": "#responded"
    }
  ],
  "id": 26,
  "labels": [
    {
      "id": 35,
      "title": "#opened"
    }
  ],
  "labelsCombination": 2,
  "loading": false,
  "name": "Count Report",
  "operationType": "Edit"
},Custom values applied successfully,
Last Module: Care Config Settings -- duration modal
Last Test: Care Config Settings -- duration modal - Duration Modal component and default values
Warning: PhantomJS timed out, possibly due to a missing QUnit start() call. Use --force to continue.

Aborted due to warnings.

```
